### PR TITLE
Revert "Bump itemadapter from 0.11.0 to 0.12.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-itemadapter==0.12.0
+itemadapter==0.11.0
 Requests==2.32.4
 scrapy==2.13.3
 scrapy_playwright==0.0.43


### PR DESCRIPTION
Reverts nit-in/download_ncert_books#26